### PR TITLE
fix(django-rq/templates): updated job.status to job.get_status

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -82,7 +82,7 @@
                     {% if job.get_status %}
                         {{ job.get_status }}
                     {% else %}
-                        {{ job.status }}
+                        {{ job.get_status }}
                     {% endif %}
                 </div>
             </div>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -88,7 +88,7 @@
                                     {% if job.get_status|length != 0 %}
                                         {{ job.get_status }}
                                     {% else %}
-                                        {{ job.status }}
+                                        {{ job.get_status }}
                                     {% endif %}
                                 </td>
                                 <td>{{ job.func_name }}</td>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data = { '': ['README.rst'] },
-    install_requires=['django', 'rq>=0.3.4'],
+    install_requires=['django', 'rq>=0.4.6'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
When using the django_rq.urls, a depreciation warning is thrown because job.status is depreciated in python-rq. This prevents you from viewing the jobs entirely. The templates have been updated accordingly.

Closes #88.