### PR TITLE
Fix job.get_status check on job detail page.

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -79,7 +79,7 @@
             <div>
                 <label class="required">Status:</label>
                 <div class="data">
-                    {% if job.get_status %}
+                    {% if job.get_status|length != 0 %}
                         {{ job.get_status }}
                     {% else %}
                         {{ job.status }}


### PR DESCRIPTION
Should have caught this in #87 but I missed the get_status call in the job_detail page. Fixes #88. Provides better backwards compatibility than #89.