### PR TITLE
Allow connection to use StrictRedis instead of Redis

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -48,8 +48,10 @@ def get_redis_connection(config, use_strict_redis=False):
     """
     Returns a redis connection from a connection config
     """
+    redis_cls = redis.StrictRedis if use_strict_redis else redis.Redis
+
     if 'URL' in config:
-        return redis.from_url(config['URL'], db=config['DB'])
+        return redis_cls.from_url(config['URL'], db=config['DB'])
     if 'USE_REDIS_CACHE' in config.keys():
 
         from django.core.cache import get_cache
@@ -74,19 +76,9 @@ def get_redis_connection(config, use_strict_redis=False):
             return cache._client
 
     if 'UNIX_SOCKET_PATH' in config:
-        if use_strict_redis:
-            return redis.StrictRedis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
-        else: 
-            return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
+        return redis_cls(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
 
-    if use_strict_redis:
-        return redis.StrictRedis(host=config['HOST'],
-                                 port=config['PORT'], db=config['DB'],
-                                 password=config.get('PASSWORD', None))
-    else:
-        return redis.Redis(host=config['HOST'],
-                           port=config['PORT'], db=config['DB'],
-                           password=config.get('PASSWORD', None))
+    return redis_cls(host=config['HOST'], port=config['PORT'], db=config['DB'], password=config.get('PASSWORD', None))
 
 
 def get_connection(name='default', use_strict_redis=False):

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -44,7 +44,7 @@ class DjangoRQ(Queue):
             thread_queue.add(self, args, kwargs)
 
 
-def get_redis_connection(config, strict_redis=False):
+def get_redis_connection(config, use_strict_redis=False):
     """
     Returns a redis connection from a connection config
     """
@@ -74,12 +74,12 @@ def get_redis_connection(config, strict_redis=False):
             return cache._client
 
     if 'UNIX_SOCKET_PATH' in config:
-        if strict_redis:
+        if use_strict_redis:
             return redis.StrictRedis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
         else: 
             return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
 
-    if strict_redis:
+    if use_strict_redis:
         return redis.StrictRedis(host=config['HOST'],
                                  port=config['PORT'], db=config['DB'],
                                  password=config.get('PASSWORD', None))
@@ -89,12 +89,12 @@ def get_redis_connection(config, strict_redis=False):
                            password=config.get('PASSWORD', None))
 
 
-def get_connection(name='default', strict_redis=False):
+def get_connection(name='default', use_strict_redis=False):
     """
     Returns a Redis connection to use based on parameters in settings.RQ_QUEUES
     """
     from .settings import QUEUES
-    return get_redis_connection(QUEUES[name], strict_redis)
+    return get_redis_connection(QUEUES[name], use_strict_redis)
 
 
 def get_connection_by_index(index):

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -44,7 +44,7 @@ class DjangoRQ(Queue):
             thread_queue.add(self, args, kwargs)
 
 
-def get_redis_connection(config):
+def get_redis_connection(config, strict_redis=False):
     """
     Returns a redis connection from a connection config
     """
@@ -72,21 +72,29 @@ def get_redis_connection(config):
         else:
             # We're using django-redis-cache
             return cache._client
-        
+
     if 'UNIX_SOCKET_PATH' in config:
-        return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
+        if strict_redis:
+            return redis.StrictRedis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
+        else: 
+            return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
 
-    return redis.Redis(host=config['HOST'],
-                       port=config['PORT'], db=config['DB'],
-                       password=config.get('PASSWORD', None))
+    if strict_redis:
+        return redis.StrictRedis(host=config['HOST'],
+                                 port=config['PORT'], db=config['DB'],
+                                 password=config.get('PASSWORD', None))
+    else:
+        return redis.Redis(host=config['HOST'],
+                           port=config['PORT'], db=config['DB'],
+                           password=config.get('PASSWORD', None))
 
 
-def get_connection(name='default'):
+def get_connection(name='default', strict_redis=False):
     """
     Returns a Redis connection to use based on parameters in settings.RQ_QUEUES
     """
     from .settings import QUEUES
-    return get_redis_connection(QUEUES[name])
+    return get_redis_connection(QUEUES[name], strict_redis)
 
 
 def get_connection_by_index(index):


### PR DESCRIPTION
The addition of a `strict_redis` kwarg on `get_connection()` allows projects that want (or need) to take advantage of `redis.StrictRedis()` to do so in a more pythonic way: without having to manually set up said connections. 