### PR TITLE
Add rqscheduler command to RQ Scheduler section of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,10 @@ instance for queues defined in settings.py's ``RQ_QUEUES``. For example:
     scheduler = django_rq.get_scheduler('default')
     job = scheduler.enqueue_at(datetime(2020, 10, 10), func)
 
+You can use also use the management command ``rqscheduler`` to start the scheduler::
+
+    python manage.py rqscheduler
+
 Support for django-redis and django-redis-cache
 -----------------------------------------------
 


### PR DESCRIPTION
This command exists since 0.6, but was not documented in the README.