### PR TITLE
Fixed the RemovedInDjango19Warning deprecation warning

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -54,8 +54,12 @@ def get_redis_connection(config, use_strict_redis=False):
         return redis_cls.from_url(config['URL'], db=config['DB'])
     if 'USE_REDIS_CACHE' in config.keys():
 
-        from django.core.cache import get_cache
-        cache = get_cache(config['USE_REDIS_CACHE'])
+        try:
+            from django.core.cache import caches
+            cache = caches[config['USE_REDIS_CACHE']]
+        except ImportError:
+            from django.core.cache import get_cache
+            cache = get_cache(config['USE_REDIS_CACHE'])
 
         if hasattr(cache, 'client'):
             # We're using django-redis. The cache's `client` attribute


### PR DESCRIPTION
This should resolve issue #101. I ran the tests locally and they pass. Please note that when you run the tests you get a new warning.

```
RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
```

I'm not sure how or if this needs to be resolved.