### PR TITLE
Sort the queues by name

### DIFF
--- a/django_rq/settings.py
+++ b/django_rq/settings.py
@@ -13,7 +13,7 @@ BURST = getattr(settings, 'RQ_BURST', False)
 
 # All queues in list format so we can get them by index, includes failed queues
 QUEUES_LIST = []
-for key, value in QUEUES.items():
+for key, value in sorted(QUEUES.items()):
     QUEUES_LIST.append({'name': key, 'connection_config': value})
 for config in get_unique_connection_configs():
     QUEUES_LIST.append({'name': 'failed', 'connection_config': config})


### PR DESCRIPTION
This change makes the ordering of queues deterministic across multiple instances of `django-rq`. This means that in load-balanced environments (like Heroku), a path like `/rq/queues/1` will point to the same queue regardless of the instance that serves the request.