### PR TITLE
allow to specify db number in url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,7 @@ Installation
             'DEFAULT_TIMEOUT': 360,
         },
         'high': {
-            'URL': os.getenv('REDISTOGO_URL', 'redis://localhost:6379'), # If you're on Heroku
-            'DB': 0,
+            'URL': os.getenv('REDISTOGO_URL', 'redis://localhost:6379/0'), # If you're on Heroku
             'DEFAULT_TIMEOUT': 500,
         },
         'low': {

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -51,7 +51,7 @@ def get_redis_connection(config, use_strict_redis=False):
     redis_cls = redis.StrictRedis if use_strict_redis else redis.Redis
 
     if 'URL' in config:
-        return redis_cls.from_url(config['URL'], db=config['DB'])
+        return redis_cls.from_url(config['URL'], db=config.get('DB'))
     if 'USE_REDIS_CACHE' in config.keys():
 
         try:

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -123,6 +123,12 @@ RQ_QUEUES = {
         'URL': 'redis://username:password@host:1234/',
         'DB': 4,
     },
+    'url_with_db': {
+        'URL': 'redis://username:password@host:1234/5',
+    },
+    'url_default_db': {
+        'URL': 'redis://username:password@host:1234',
+    },
     'django_rq_test': {
         'HOST': 'localhost',
         'PORT': 6379,

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -131,6 +131,36 @@ class QueuesTest(TestCase):
         self.assertEqual(connection_kwargs['db'], 4)
         self.assertEqual(connection_kwargs['password'], 'password')
 
+    def test_get_queue_url_with_db(self):
+        """
+        Test that get_queue use the right parameters for queues using URL for
+        connection, where URL contains the db number (either as querystring
+        or path segment).
+        """
+        config = QUEUES['url_with_db']
+        queue = get_queue('url_with_db')
+        connection_kwargs = queue.connection.connection_pool.connection_kwargs
+        self.assertEqual(queue.name, 'url_with_db')
+        self.assertEqual(connection_kwargs['host'], 'host')
+        self.assertEqual(connection_kwargs['port'], 1234)
+        self.assertEqual(connection_kwargs['db'], 5)
+        self.assertEqual(connection_kwargs['password'], 'password')
+
+    def test_get_queue_url_with_db_default(self):
+        """
+        Test that get_queue use the right parameters for queues using URL for
+        connection, where no DB given and URL does not contain the db number
+        (redis-py defaults to 0, should not break).
+        """
+        config = QUEUES['url_default_db']
+        queue = get_queue('url_default_db')
+        connection_kwargs = queue.connection.connection_pool.connection_kwargs
+        self.assertEqual(queue.name, 'url_default_db')
+        self.assertEqual(connection_kwargs['host'], 'host')
+        self.assertEqual(connection_kwargs['port'], 1234)
+        self.assertEqual(connection_kwargs['db'], 0)
+        self.assertEqual(connection_kwargs['password'], 'password')
+
     def test_get_queue_test(self):
         """
         Test that get_queue use the right parameters for `test`


### PR DESCRIPTION
when doing config via env vars it's nice to be able to pass the whole configuration in one url string

underlying redis-py library supports this