### PR TITLE
Typo in urls.py code example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Installation
 .. code-block:: python
 
     urlpatterns += patterns('',
-        (r'^django-rq/', include('django_rq.urls')),
+        url(r'^django-rq/', include('django_rq.urls')),
     )
 
 


### PR DESCRIPTION
This raises a cryptic exception:

Traceback (most recent call last):
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/utils/autoreload.py", line 229, in wrapper
    fn(*args, **kwargs)
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/core/management/commands/runserver.py", line 107, in inner_run
    autoreload.raise_last_exception()
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/utils/autoreload.py", line 252, in raise_last_exception
    six.reraise(*_exception)
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/utils/autoreload.py", line 229, in wrapper
    fn(*args, **kwargs)
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/apps/registry.py", line 115, in populate
    app_config.ready()
  File "/vagrant/venv/local/lib/python2.7/site-packages/debug_toolbar/apps.py", line 15, in ready
    dt_settings.patch_all()
  File "/vagrant/venv/local/lib/python2.7/site-packages/debug_toolbar/settings.py", line 228, in patch_all
    patch_root_urlconf()
  File "/vagrant/venv/local/lib/python2.7/site-packages/debug_toolbar/settings.py", line 216, in patch_root_urlconf
    reverse('djdt:render_panel')
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 549, in reverse
    app_list = resolver.app_dict[ns]
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 351, in app_dict
    self._populate()
  File "/vagrant/venv/local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 297, in _populate
    p_pattern = pattern.regex.pattern
AttributeError: 'tuple' object has no attribute 'regex'

Thanks!