### PR TITLE
Compatibility with Django 1.9

### DIFF
--- a/django_rq/templates/django_rq/clear_queue.html
+++ b/django_rq/templates/django_rq/clear_queue.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/confirm_action.html
+++ b/django_rq/templates/django_rq/confirm_action.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/delete_job.html
+++ b/django_rq/templates/django_rq/delete_job.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/index.html
+++ b/django_rq/templates/django_rq/index.html
@@ -1,7 +1,5 @@
 {% extends "admin/index.html" %}
 
-{% load url from future %}
-
 {% block sidebar %}
     
 

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 {% load admin_static %}
-{% load url from future %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>table {width: 100%;}</style>

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -1,24 +1,22 @@
 from django.conf.urls import url
-from .views import stats, jobs, finished_jobs, started_jobs, deferred_jobs
-from .views import clear_queue, job_detail, delete_job, actions, requeue_job_view
-
+import views
 
 urlpatterns = [
-    url(r'^$', stats, name='rq_home'),
-    url(r'^queues/(?P<queue_index>[\d]+)/$', jobs, name='rq_jobs'),
+    url(r'^$', views.stats, name='rq_home'),
+    url(r'^queues/(?P<queue_index>[\d]+)/$', views.jobs, name='rq_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/finished/$',
-        finished_jobs, name='rq_finished_jobs'),
+        views.finished_jobs, name='rq_finished_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/started/$',
-        started_jobs, name='rq_started_jobs'),
+        views.started_jobs, name='rq_started_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/deferred/$',
-        deferred_jobs, name='rq_deferred_jobs'),
-    url(r'^queues/(?P<queue_index>[\d]+)/empty/$', clear_queue, name='rq_clear'),
-    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$', job_detail,
+        views.deferred_jobs, name='rq_deferred_jobs'),
+    url(r'^queues/(?P<queue_index>[\d]+)/empty/$', views.clear_queue, name='rq_clear'),
+    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$', views.job_detail,
         name='rq_job_detail'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/delete/$',
-        delete_job, name='rq_delete_job'),
+        views.delete_job, name='rq_delete_job'),
     url(r'^queues/actions/(?P<queue_index>[\d]+)/$',
-        actions, name='rq_actions'),
+        views.actions, name='rq_actions'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/requeue/$',
-        requeue_job_view, name='rq_requeue_job'),
+        views.requeue_job_view, name='rq_requeue_job'),
 ]

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -1,21 +1,24 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from .views import stats, jobs, finished_jobs, started_jobs, deferred_jobs
+from .views import clear_queue, job_detail, delete_job, actions, requeue_job_view
 
-urlpatterns = patterns('django_rq.views',
-    url(r'^$', 'stats', name='rq_home'),
-    url(r'^queues/(?P<queue_index>[\d]+)/$', 'jobs', name='rq_jobs'),
+
+urlpatterns = [
+    url(r'^$', stats, name='rq_home'),
+    url(r'^queues/(?P<queue_index>[\d]+)/$', jobs, name='rq_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/finished/$',
-        'finished_jobs', name='rq_finished_jobs'),
+        finished_jobs, name='rq_finished_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/started/$',
-        'started_jobs', name='rq_started_jobs'),
+        started_jobs, name='rq_started_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/deferred/$',
-        'deferred_jobs', name='rq_deferred_jobs'),
-    url(r'^queues/(?P<queue_index>[\d]+)/empty/$', 'clear_queue', name='rq_clear'),
-    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$', 'job_detail',
+        deferred_jobs, name='rq_deferred_jobs'),
+    url(r'^queues/(?P<queue_index>[\d]+)/empty/$', clear_queue, name='rq_clear'),
+    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$', job_detail,
         name='rq_job_detail'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/delete/$',
-        'delete_job', name='rq_delete_job'),
+        delete_job, name='rq_delete_job'),
     url(r'^queues/actions/(?P<queue_index>[\d]+)/$',
-        'actions', name='rq_actions'),
+        actions, name='rq_actions'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/requeue/$',
-        'requeue_job_view', name='rq_requeue_job'),
-)
+        requeue_job_view, name='rq_requeue_job'),
+]


### PR DESCRIPTION
I was testing Django 1.9 and it needs the following fixes:

* Remove 1.9 deprecation warnings in urls.py
* Removing {% load url from future %} because it is deprecated

Thanks for **django-rq**, it is awesome =)

PS: Perhaps, you should merge in a django_1.9 branch !