### PR TITLE
Removed 'load url from future' for compatibility with Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,25 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 
 env:
-  - DJANGO=1.8.0
+  - DJANGO=1.9.0
+  - DJANGO=1.8.7
   - DJANGO=1.7.7
   - DJANGO=1.6.11
   - DJANGO=1.5.12
-  - DJANGO=1.4.20
 
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO=1.4.20
     - python: "2.6"
       env: DJANGO=1.7.7
     - python: "2.6"
-      env: DJANGO=1.8.0
+      env: DJANGO=1.8.7
+    - python: "2.6"
+      env: DJANGO=1.9.0
+    - python: "3.3"
+      env: DJANGO=1.9.0
 
 install:
   - pip install Django==$DJANGO times

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ and easily use them in your project.
 Requirements
 ============
 
-* `Django <https://www.djangoproject.com/>`_
+* `Django <https://www.djangoproject.com/>`_ (1.5+)
 * `RQ`_
 
 ============

--- a/django_rq/templates/django_rq/clear_queue.html
+++ b/django_rq/templates/django_rq/clear_queue.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/confirm_action.html
+++ b/django_rq/templates/django_rq/confirm_action.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/delete_job.html
+++ b/django_rq/templates/django_rq/delete_job.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/index.html
+++ b/django_rq/templates/django_rq/index.html
@@ -1,7 +1,5 @@
 {% extends "admin/index.html" %}
 
-{% load url from future %}
-
 {% block sidebar %}
     
 

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 {% load admin_static %}
-{% load url from future %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -1,7 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{% load url from future %}
-
 {% block extrastyle %}
     {{ block.super }}
     <style>table {width: 100%;}</style>

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -13,6 +13,11 @@ try:
         REDIS_CACHE_TYPE = 'django-redis-cache'
 except ImportError:
     REDIS_CACHE_TYPE = 'none'
+try:
+    from django.utils.log import NullHandler
+    nullhandler = 'django.utils.log.NullHandler'
+except:
+    nullhandler = 'logging.NullHandler'
 
 INSTALLED_APPS = [
     'django.contrib.contenttypes',
@@ -74,7 +79,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': nullhandler,
         },
     },
     'loggers': {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django', 'rq>=0.5.0'],
+    install_requires=['django>=1.5.0', 'rq>=0.5.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
From the docs of the django project:

One deprecated feature worth noting is the shift to “new-style” url tag. Prior to Django 1.3, syntax like {% url myview %} was interpreted incorrectly (Django considered "myview" to be a literal name of a view, not a template variable named myview). Django 1.3 and above introduced the {% load url from future %} syntax to bring in the corrected behavior where myview was seen as a variable.

The upshot of this is that if you are not using {% load url from future %} in your templates, you’ll need to change tags like {% url myview %} to {% url "myview" %}. If you were using {% load url from future %} you can simply remove that line under Django 1.5

This tag shouldn't be necessary anymore since Django 1.5.