### PR TITLE
Make *_at fields in Job class timezone aware

### DIFF
--- a/django_rq/job.py
+++ b/django_rq/job.py
@@ -1,0 +1,26 @@
+try:
+    from pytz import timezone
+    from django.utils.timezone import make_aware
+except ImportError:
+    pass
+
+from rq.job import Job
+
+TIMEZONE_AWARE_FIELDS = (
+    'created_at',
+    'enqueued_at',
+    'started_at',
+    'ended_at',
+)
+
+class TZAwareJob(Job):
+    def __getattribute__(self, name):
+        attr = super(TZAwareJob, self).__getattribute__(name)
+        if name in TIMEZONE_AWARE_FIELDS and attr is not None:
+            try:
+                return make_aware(attr, timezone('UTC'))
+            except NameError:
+                return attr
+        return attr
+
+

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -6,6 +6,8 @@ from rq.queue import FailedQueue, Queue
 
 from django_rq import thread_queue
 
+from .job import TZAwareJob
+
 
 def get_commit_mode():
     """
@@ -32,7 +34,9 @@ class DjangoRQ(Queue):
         autocommit = kwargs.pop('autocommit', None)
         self._autocommit = get_commit_mode() if autocommit is None else autocommit
 
-        return super(DjangoRQ, self).__init__(*args, **kwargs)
+        job_class = kwargs.pop('job_class', TZAwareJob)
+
+        return super(DjangoRQ, self).__init__(job_class=job_class, *args, **kwargs)
 
     def original_enqueue_call(self, *args, **kwargs):
         return super(DjangoRQ, self).enqueue_call(*args, **kwargs)

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -10,12 +10,12 @@ from django.shortcuts import redirect, render
 from redis.exceptions import ResponseError
 from rq import requeue_job, Worker
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
 from rq.registry import (DeferredJobRegistry, FinishedJobRegistry,
                          StartedJobRegistry)
 
 from .queues import get_connection, get_queue_by_index
 from .settings import QUEUES_LIST
+from .job import TZAwareJob as Job
 
 
 @staff_member_required


### PR DESCRIPTION
Should fix #32 without causing any issue if `pytz` is not installed.

Create a new sublcass of `rq.job.Job` called `django_rq.job.TZAwareJob`. This makes fields in `job.TIMEZONE_AWARE_FIELDS` timezone aware using `django.utils.timezone.make_aware`.

We then modify `DjangoRQ` and `views` to use `TZAwareJob` instead of `Job`.

A couple of thoughts worth considering before pulling to master:
- might be worth checking django's USE_TZ setting?
- in my tests, my queue list still doesn't appear with `created_at` and `enqueued_at` timezone aware. Not sure why this is?
