### PR TITLE
Clean up EXCEPTION_HANDLER implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ Installation
         'high': {
             'URL': os.getenv('REDISTOGO_URL', 'redis://localhost:6379/0'), # If you're on Heroku
             'DEFAULT_TIMEOUT': 500,
-            'EXCEPTION_HANDLERS': ['path.to.my.handler'], # If you need custom exception handlers
         },
         'low': {
             'HOST': 'localhost',
@@ -58,6 +57,8 @@ Installation
             'DB': 0,
         }
     }
+
+    RQ_EXCEPTION_HANDLERS = ['path.to.my.handler'] # If you need custom exception handlers
 
 * Include ``django_rq.urls`` in your ``urls.py``:
 

--- a/django_rq/management/commands/rqscheduler.py
+++ b/django_rq/management/commands/rqscheduler.py
@@ -19,8 +19,16 @@ class Command(BaseCommand):
             help="How often the scheduler checks for new jobs to add to the "
                  "queue (in seconds).",
         ),
+        make_option(
+            '--queue',
+            type=str,
+            dest='queue',
+            default='default',
+            help="Name of the queue used for scheduling.",
+        ),
     )
 
-    def handle(self, queue='default', *args, **options):
-        scheduler = get_scheduler(name=queue, interval=options.get('interval'))
+    def handle(self, *args, **options):
+        scheduler = get_scheduler(
+            name=options.get('queue'), interval=options.get('interval'))
         scheduler.run()

--- a/django_rq/settings.py
+++ b/django_rq/settings.py
@@ -17,3 +17,6 @@ for key, value in sorted(QUEUES.items()):
     QUEUES_LIST.append({'name': key, 'connection_config': value})
 for config in get_unique_connection_configs():
     QUEUES_LIST.append({'name': 'failed', 'connection_config': config})
+
+# Get exception handlers
+EXCEPTION_HANDLERS = getattr(settings, 'RQ_EXCEPTION_HANDLERS', [])

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -1,9 +1,8 @@
-from django.conf import settings
-
 from rq import Worker
 from rq.utils import import_attribute
 
 from .queues import get_queues
+from .settings import EXCEPTION_HANDLERS
 
 
 def get_exception_handlers():
@@ -13,12 +12,7 @@ def get_exception_handlers():
         'EXCEPTION_HANDLERS': ['path.to.handler'],
     }
     """
-    RQ = getattr(settings, 'RQ', {})
-    exception_handlers = []
-    for path in RQ.get('EXCEPTION_HANDLERS', []):
-        handler = import_attribute(path)
-        exception_handlers.append(handler)
-    return exception_handlers
+    return [import_attribute(path) for path in EXCEPTION_HANDLERS]
 
 
 def get_worker(*queue_names):


### PR DESCRIPTION
I found there were a couple problems with the implementation for EXCEPTION_HANDLERS and cleaned them up.

1. The README documentation didn't match how it was implemented.
2. The implementation bypassed the django_rq settings and accessed an `RQ` settings variable directly.

