### PR TITLE
sort the queues only by name

### DIFF
--- a/django_rq/settings.py
+++ b/django_rq/settings.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -13,7 +15,7 @@ BURST = getattr(settings, 'RQ_BURST', False)
 
 # All queues in list format so we can get them by index, includes failed queues
 QUEUES_LIST = []
-for key, value in sorted(QUEUES.items()):
+for key, value in sorted(QUEUES.items(), key=itemgetter(0)):
     QUEUES_LIST.append({'name': key, 'connection_config': value})
 for config in get_unique_connection_configs():
     QUEUES_LIST.append({'name': 'failed', 'connection_config': config})


### PR DESCRIPTION
It sorts RQ_QUEUES only by key (queue name). 
This issue was already resolved in #118  but unfortunately it doesn't work in our environment (behind load-balancer). 
`.../django-rq/queues/3/` each request point to the different queue.