### PR TITLE
Custom queue class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,8 +278,8 @@ For more info, refer to `Raven's documentation <http://raven.readthedocs.org/>`_
 Custom queue class
 ------------------
 
-By default every queue provided by the `DjangoRQ` class, but If you want to use a custom class to your queues
-use `QUEUE_CLASS` option for a queue in `RQ_QUEUES` setting
+By default every queue provided by the ``DjangoRQ`` class, but If you want to use a custom class to your queues
+use ``QUEUE_CLASS`` option for a queue in ``RQ_QUEUES`` setting
 
 .. code-block:: python
 
@@ -292,7 +292,7 @@ use `QUEUE_CLASS` option for a queue in `RQ_QUEUES` setting
         }
     }
 
-or you can specify a custom class for every queue by `RQ` settings:
+or you can specify a custom class for every queue by ``RQ`` settings:
 
 .. code-block:: python
 
@@ -300,7 +300,7 @@ or you can specify a custom class for every queue by `RQ` settings:
         'QUEUE_CLASS': 'module.path.CustomClass',
     }
 
-Custom queue class should inherit `django_rq.queues.DjangoRQ`.
+Custom queue class should inherit ``django_rq.queues.DjangoRQ``.
 
 Testing tip
 -----------

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,11 @@ with the path to your worker::
 
     python manage.py rqworker high default low --worker-class 'path.to.GeventWorker'
 
+If you need to use a custom queue class, you can pass in the ``--queue-class`` flag
+with the path to your queue class::
+
+    python manage.py rqworker high default low --queue-class 'path.to.CustomQueue'
+
 Support for RQ Scheduler
 ------------------------
 
@@ -269,6 +274,33 @@ transports (the default transport). Please configure ``Raven`` to use
     }
 
 For more info, refer to `Raven's documentation <http://raven.readthedocs.org/>`_.
+
+Custom queue class
+------------------
+
+By default every queue provided by the `DjangoRQ` class, but If you want to use a custom class to your queues
+use `QUEUE_CLASS` option for a queue in `RQ_QUEUES` setting
+
+.. code-block:: python
+
+    RQ_QUEUES = {
+        'default': {
+            'HOST': 'localhost',
+            'PORT': 6379,
+            'DB': 0,
+            'QUEUE_CLASS': 'module.path.CustomClass',
+        }
+    }
+
+or you can specify a custom class for every queue by `RQ` settings:
+
+.. code-block:: python
+
+    RQ = {
+        'QUEUE_CLASS': 'module.path.CustomClass',
+    }
+
+Custom queue class should inherit `django_rq.queues.DjangoRQ`.
 
 Testing tip
 -----------

--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -1,3 +1,4 @@
+from django.utils import six
 from rq.decorators import job as _rq_job
 
 from .queues import get_queue
@@ -18,14 +19,7 @@ def job(func_or_queue, connection=None, *args, **kwargs):
         func = None
         queue = func_or_queue
 
-    try:
-        from django.utils import six
-        string_type = six.string_types
-    except ImportError:
-        # for django lt v1.5 and python 2
-        string_type = basestring
-
-    if isinstance(queue, string_type):
+    if isinstance(queue, six.string_types):
         try:
             queue = get_queue(queue)
             if connection is None:

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -56,6 +56,13 @@ class Command(BaseCommand):
             help='RQ Worker class to use'
         ),
         make_option(
+            '--queue-class',
+            action='store',
+            dest='queue_class',
+            default='django_rq.queues.DjangoRQ',
+            help='Queues class to use'
+        ),
+        make_option(
             '--name',
             action='store',
             dest='name',
@@ -89,8 +96,8 @@ class Command(BaseCommand):
 
         try:
             # Instantiate a worker
-            worker_class = import_attribute(options.get('worker_class', 'rq.Worker'))
-            queues = get_queues(*args)
+            worker_class = import_attribute(options['worker_class'])
+            queues = get_queues(*args, queue_class=import_attribute(options['queue_class']))
             w = worker_class(
                 queues,
                 connection=queues[0].connection,

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -47,10 +47,12 @@ class Command(BaseCommand):
                             default='rq.Worker', help='RQ Worker class to use')
         parser.add_argument('--pid', action='store', dest='pid',
                             default=None, help='PID file to write the worker`s pid into')
-        parser.add_argument('--burst',action='store', dest='burst',
+        parser.add_argument('--burst', action='store', dest='burst',
                             default=False, help='Run worker in burst mode')
         parser.add_argument('--name', action='store', dest='name',
                             default=None, help='Name of the worker')
+        parser.add_argument('--queue-class', action='store', dest='queue_class',
+                            default='django_rq.queues.DjangoRQ', help='Queues class to use')
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -34,7 +34,13 @@ def get_queue_class(config):
     elif 'QUEUE_CLASS' in RQ:
         queue_class = RQ.get('QUEUE_CLASS')
 
-    if isinstance(queue_class, basestring):
+    try:
+        from django.utils import six
+        string_type = six.string_types
+    except ImportError:
+        string_type = basestring
+
+    if isinstance(queue_class, string_type):
         queue_class = import_attribute(queue_class)
     return queue_class
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -1,8 +1,8 @@
 from django.conf import settings
-from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
 
 import redis
+from rq.utils import import_attribute
 from rq.queue import FailedQueue, Queue
 
 from django_rq import thread_queue
@@ -35,7 +35,7 @@ def get_queue_class(config):
         queue_class = RQ.get('QUEUE_CLASS')
 
     if isinstance(queue_class, basestring):
-        queue_class = import_string(queue_class)
+        queue_class = import_attribute(queue_class)
     return queue_class
 
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -150,7 +150,7 @@ def get_queue_by_index(index):
     config = QUEUES_LIST[int(index)]
     if config['name'] == 'failed':
         return FailedQueue(connection=get_redis_connection(config['connection_config']))
-    return DjangoRQ(
+    return get_queue_class(config)(
         config['name'],
         connection=get_redis_connection(config['connection_config']),
         async=config.get('ASYNC', True))

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -141,7 +141,7 @@ def get_queue(name='default', default_timeout=None, async=None,
 
     if default_timeout is None:
         default_timeout = QUEUES[name].get('DEFAULT_TIMEOUT')
-    if queue_class is None or queue_class == DjangoRQ:
+    if queue_class is None:
         queue_class = get_queue_class(QUEUES[name])
     return queue_class(name, default_timeout=default_timeout,
                        connection=get_connection(name), async=async,

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
 
 import redis
 from rq.utils import import_attribute
@@ -34,13 +35,7 @@ def get_queue_class(config):
     elif 'QUEUE_CLASS' in RQ:
         queue_class = RQ.get('QUEUE_CLASS')
 
-    try:
-        from django.utils import six
-        string_type = six.string_types
-    except ImportError:
-        string_type = basestring
-
-    if isinstance(queue_class, string_type):
+    if isinstance(queue_class, six.string_types):
         queue_class = import_attribute(queue_class)
     return queue_class
 

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -110,6 +110,7 @@ RQ_QUEUES = {
         'PORT': 1,
         'DB': 1,
         'DEFAULT_TIMEOUT': 400,
+        'QUEUE_CLASS': 'django_rq.tests.DummyQueue'
     },
     'test2': {
         'HOST': REDIS_HOST,

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+REDIS_HOST = os.environ.get("REDIS_HOST", 'localhost')
 
 SECRET_KEY = 'a'
 
@@ -39,7 +41,7 @@ if REDIS_CACHE_TYPE == 'django-redis':
     CACHES = {
         'django-redis': {
             'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': 'localhost:6379:2',
+            'LOCATION': '%s:6379:2' % REDIS_HOST,
             'KEY_PREFIX': 'django-rq-tests',
             'OPTIONS': {
                 'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
@@ -51,7 +53,7 @@ elif REDIS_CACHE_TYPE == 'django-redis-cache':
     CACHES = {
         'django-redis-cache': {
             'BACKEND': 'redis_cache.cache.RedisCache',
-            'LOCATION': 'localhost:6379',
+            'LOCATION': '%s:6379' % REDIS_HOST,
             'KEY_PREFIX': 'django-rq-tests',
             'OPTIONS': {
                 'DB': 2,
@@ -90,36 +92,37 @@ LOGGING = {
     }
 }
 
+
 RQ_QUEUES = {
     'default': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 0,
         'DEFAULT_TIMEOUT': 500
     },
     'test': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 1,
         'DB': 1,
     },
     'test1': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 1,
         'DB': 1,
-        'DEFAULT_TIMEOUT': 400
+        'DEFAULT_TIMEOUT': 400,
     },
     'test2': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 1,
         'DB': 1,
     },
     'test3': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 1,
     },
     'async': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 1,
         'ASYNC': False,
@@ -135,12 +138,11 @@ RQ_QUEUES = {
         'URL': 'redis://username:password@host:1234',
     },
     'django_rq_test': {
-        'HOST': 'localhost',
+        'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 0,
     },
 }
-
 RQ = {
     'AUTOCOMMIT': False,
 }

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -328,6 +328,7 @@ class ViewTest(TestCase):
         user.save()
         self.client = Client()
         self.client.login(username=user.username, password='pass')
+        get_queue('django_rq_test').connection.flushall()
 
     def test_requeue_job(self):
         """

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -21,7 +21,7 @@ from rq.registry import (DeferredJobRegistry, FinishedJobRegistry,
 from django_rq.decorators import job
 from django_rq.queues import (
     get_connection, get_queue, get_queue_by_index, get_queues,
-    get_unique_connection_configs
+    get_unique_connection_configs, DjangoRQ
 )
 from django_rq import thread_queue
 from django_rq.workers import get_worker
@@ -592,3 +592,22 @@ class RedisCacheTest(TestCase):
         self.assertEqual(connection_kwargs['port'], int(cachePort))
         self.assertEqual(connection_kwargs['db'], int(cacheDBNum))
         self.assertEqual(connection_kwargs['password'], None)
+
+
+class DummyQueue(DjangoRQ):
+    """Just Fake class for the following test"""
+
+
+class QueueClassTest(TestCase):
+
+    def test_default_queue_class(self):
+        queue = get_queue('test')
+        self.assertIsInstance(queue, DjangoRQ)
+
+    def test_for_queue(self):
+        queue = get_queue('test1')
+        self.assertIsInstance(queue, DummyQueue)
+
+    def test_in_kwargs(self):
+        queue = get_queue('test', queue_class=DummyQueue)
+        self.assertIsInstance(queue, DummyQueue)


### PR DESCRIPTION
I don't know why It is not implemented yet, but I think it is useful. For example: We have the project,  and we don't want to  run redis at the test environment or in other special environment. Yeah, writing something like this: 
```python
if getattr(settings, 'DIRECT_CALL', False):
    job()
else:
   job.delay()
```
at every call is not good idea (for me)
Next changes give for us more clear way to do this, I can use custom Queue class for this:
```python
class DummyQueue(DjangoRQ):
    def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                     result_ttl=None, ttl=None, description=None,
                     depends_on=None, job_id=None, at_front=False):
        return partial(func, args=args, kwargs=kwargs)
``` 
and then use them at the settings.
I think somebody will find other cases to use this ability: adding extra logic for new jobs, or adding special logs, etc.