### PR TITLE
Adding in Requeue All feature for Failed Queues

### DIFF
--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -36,6 +36,9 @@
 
 <div id="content-main">
     <ul class="object-tools">
+        {% if queue.name == 'failed' %}
+            <li><a href="{% url 'rq_requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
+        {% endif %}
         <li><a href="{% url 'rq_clear' queue_index %}" class="deletelink">Empty Queue</a></li>
     </ul>
     <div class="module" id="changelist">

--- a/django_rq/templates/django_rq/requeue_all.html
+++ b/django_rq/templates/django_rq/requeue_all.html
@@ -1,0 +1,43 @@
+{% extends "admin/base_site.html" %}
+
+{% load admin_static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <style>
+        .data {
+            display: inline-block;
+            float: left;
+            width: 80%;
+        }
+    </style>
+    <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
+        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        Requeue All
+    </div>
+{% endblock %}
+
+{% block content_title %}<h1>Are you sure?</h1>{% endblock %}
+
+{% block content %}
+
+<div id="content-main">
+    <p>
+        Are you sure you want to requeue all {{ total_jobs }} job{{ total_jobs|pluralize }} in the queue <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>?
+        This action can not be undone.
+    </p>
+    <form action="" method="post">
+        {% csrf_token %}
+        <div>
+            <input type="submit" value="Yes, I'm sure" />
+        </div>
+    </form>
+</div>
+
+{% endblock %}

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
         views.deferred_jobs, name='rq_deferred_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/empty/$',
         views.clear_queue, name='rq_clear'),
+    url(r'^queues/(?P<queue_index>[\d]+)/requeue-all/$',
+        views.requeue_all, name='rq_requeue_all'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$',
         views.job_detail, name='rq_job_detail'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/delete/$',

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -286,6 +286,18 @@ def clear_queue(request, queue_index):
 
 
 @staff_member_required
+def requeue_all(request, queue_index):
+    queue_index = int(queue_index)
+    queue = get_queue_by_index(queue_index)
+    jobs = queue.get_jobs()
+    for job in jobs:
+        requeue_job(job.id, connection=queue.connection)
+
+    messages.info(request, 'You have successfully requeued all %d  jobs!' % len(jobs))
+    return redirect('rq_jobs', queue_index)
+
+
+@staff_member_required
 def actions(request, queue_index):
     queue_index = int(queue_index)
     queue = get_queue_by_index(queue_index)

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -290,11 +290,22 @@ def requeue_all(request, queue_index):
     queue_index = int(queue_index)
     queue = get_queue_by_index(queue_index)
     jobs = queue.get_jobs()
-    for job in jobs:
-        requeue_job(job.id, connection=queue.connection)
 
-    messages.info(request, 'You have successfully requeued all %d  jobs!' % len(jobs))
-    return redirect('rq_jobs', queue_index)
+    if request.method == 'POST':
+        # Confirmation received
+        for job in jobs:
+            requeue_job(job.id, connection=queue.connection)
+
+        messages.info(request, 'You have successfully requeued all %d jobs!' % len(jobs))
+        return redirect('rq_jobs', queue_index)
+
+    context_data = {
+        'queue_index': queue_index,
+        'queue': queue,
+        'total_jobs':len(jobs),
+    }
+
+    return render(request, 'django_rq/requeue_all.html', context_data)
 
 
 @staff_member_required


### PR DESCRIPTION
I'm using django-rq to push through lots of jobs everyday (20k+) and sometimes a bunch of them will fail at once due to unforeseen issues (> 1000 failed jobs).   It is a bit cumbersome right now to requeue everything in 100 job batches using the only admin actions.  Thus, I've added in a "Requeue All" feature / button that only shows up on failed queue, similar to how Empty Queue works across all the queues.  Makes it much easier / faster to requeue a bunch of failed tasks after a problem is resolved.

Just let me know if you have any questions or need additional updates to approve pull request - happy to help.  Django-rq has worked great for our needs!