### PR TITLE
show job result on job django admin detail page.

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -127,6 +127,12 @@
             </div>
         </div>
 
+        <div class="form-row">
+            <div>
+                <label class="required">Result:</label>
+                <div class="data">{{ job.result }}</div>
+            </div>
+        </div>
 
     </fieldset>
 


### PR DESCRIPTION
Hi,
I created this pull request, because I want to be able to see job return value on job django admin detail page.

It works for job in any state. (It display None if no result yet)