### PR TITLE
adds "compatibility mode" for positional argument support across vers…

### DIFF
--- a/django_rq/management/commands/rqenqueue.py
+++ b/django_rq/management/commands/rqenqueue.py
@@ -1,4 +1,7 @@
+from distutils.version import LooseVersion
+
 from django.core.management.base import BaseCommand
+from django.utils.version import get_version
 
 from django_rq import get_queue
 
@@ -15,6 +18,9 @@ class Command(BaseCommand):
                             help='Specify the queue [default]')
         parser.add_argument('--timeout', '-t', type='int', dest='timeout',
                             help='A timeout in seconds')
+
+        if LooseVersion(get_version()) >= LooseVersion('1.9'):
+            parser.add_argument('args', nargs='*')
 
     def handle(self, *args, **options):
         """

--- a/django_rq/management/commands/rqscheduler.py
+++ b/django_rq/management/commands/rqscheduler.py
@@ -1,4 +1,7 @@
+from distutils.version import LooseVersion
+
 from django.core.management.base import BaseCommand
+from django.utils.version import get_version
 from django_rq import get_scheduler
 
 
@@ -15,6 +18,9 @@ class Command(BaseCommand):
                             queue (in seconds).""")
         parser.add_argument('--queue', dest='queue', default='default',
                             help="Name of the queue used for scheduling.",)
+
+        if LooseVersion(get_version()) >= LooseVersion('1.9'):
+            parser.add_argument('args', nargs='*')
 
     def handle(self, *args, **options):
         scheduler = get_scheduler(

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -1,9 +1,11 @@
+from distutils.version import LooseVersion
 import os
 import importlib
 import logging
 import sys
 
 from django.core.management.base import BaseCommand
+from django.utils.version import get_version
 
 from django_rq.queues import get_queues
 from django_rq.workers import get_exception_handlers
@@ -59,6 +61,8 @@ class Command(BaseCommand):
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')
+        if LooseVersion(get_version()) >= LooseVersion('1.9'):
+            parser.add_argument('args', nargs='*')
 
     def handle(self, *args, **options):
         pid = options.get('pid')


### PR DESCRIPTION
…ions

See: https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/

> 
> Changed in Django 1.8:
> Before Django 1.8, management commands were based on the optparse module, and positional arguments were passed in *args while optional arguments were passed in **options. Now that management commands use argparse for argument parsing, all arguments are passed in **options by default, unless you name your positional arguments to args (compatibility mode). You are encouraged to exclusively use **options for new commands.