### PR TITLE
Added exit code 1 in case of connection error

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -1,6 +1,7 @@
 import os
 import importlib
 import logging
+import sys
 
 from django.core.management.base import BaseCommand
 
@@ -83,3 +84,4 @@ class Command(BaseCommand):
             w.work(burst=options.get('burst', False))
         except ConnectionError as e:
             print(e)
+            sys.exit(1)


### PR DESCRIPTION
The use case is the following : 
- you run `rqworker` supervised by [supervisord](https://supervisord.org)
- you run any system operation on redis, like updating its configuration
- you restart redis
- the worker detects Redis is down and quits with the message 

> Registering death

but also with exit code 0 which is not in Supervisor"s unexpected exit codes.

Therefore supervisord will simply not restart the `rqworker` under supervision as it thinks it has stopped normally.

Exiting with exit code 1 in case of connection error fixes this.