### PR TITLE
Fixed --burst boolean arg of rqworker command

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                             default='rq.Worker', help='RQ Worker class to use')
         parser.add_argument('--pid', action='store', dest='pid',
                             default=None, help='PID file to write the worker`s pid into')
-        parser.add_argument('--burst', action='store', dest='burst',
+        parser.add_argument('--burst', action='store_true', dest='burst',
                             default=False, help='Run worker in burst mode')
         parser.add_argument('--name', action='store', dest='name',
                             default=None, help='Name of the worker')

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -312,7 +312,7 @@ class WorkersTest(TestCase):
         """
         queue = get_queue()
         job = queue.enqueue(access_self)
-        call_command('rqworker', burst=True)
+        call_command('rqworker', '--burst')
         failed_queue = Queue(name='failed', connection=queue.connection)
         self.assertFalse(job.id in failed_queue.job_ids)
         job.delete()


### PR DESCRIPTION
While converting commands to argparse, the `--burst` flag to the `rqworker` command was badly transformed to a flag needed a parameter.