### PR TITLE
fix argument parsing to work on Django 1.8, 1.9, and 1.10

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -46,8 +46,6 @@ class Command(BaseCommand):
     args = '<queue queue ...>'
 
     def add_arguments(self, parser):
-        parser.add_argument('queues', nargs='*', type=str,
-                            help='The queues to work on, separated by space')
         parser.add_argument('--worker-class', action='store', dest='worker_class',
                             default='rq.Worker', help='RQ Worker class to use')
         parser.add_argument('--pid', action='store', dest='pid',
@@ -61,8 +59,9 @@ class Command(BaseCommand):
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')
-        if LooseVersion(get_version()) >= LooseVersion('1.9'):
-            parser.add_argument('args', nargs='*')
+        if LooseVersion(get_version()) >= LooseVersion('1.10'):
+            parser.add_argument('args', nargs='*', type=str,
+                                help='The queues to work on, separated by space')
 
     def handle(self, *args, **options):
         pid = options.get('pid')
@@ -73,7 +72,7 @@ class Command(BaseCommand):
         try:
             # Instantiate a worker
             worker_class = import_attribute(options['worker_class'])
-            queues = get_queues(*options.get('queues'), queue_class=import_attribute(options['queue_class']))
+            queues = get_queues(*args, queue_class=import_attribute(options['queue_class']))
             w = worker_class(
                 queues,
                 connection=queues[0].connection,

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -144,6 +144,11 @@ RQ_QUEUES = {
         'PORT': 6379,
         'DB': 0,
     },
+    'django_rq_test2': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+    },
 }
 RQ = {
     'AUTOCOMMIT': False,

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -192,7 +192,20 @@ class QueuesTest(TestCase):
         """
         Checks that passing queues via commandline arguments works
         """
-        self.assertRaises(KeyError, lambda: call_command('rqworker', 'some_queue'))
+        queue_names = ['django_rq_test', 'django_rq_test']
+        jobs = []
+        for queue_name in queue_names:
+            queue = get_queue(queue_name)
+            jobs.append({
+                'job': queue.enqueue(divide, 42, 1),
+                'finished_job_registry': FinishedJobRegistry(queue.name, queue.connection),
+            })
+
+        call_command('rqworker', *queue_names, burst=True)
+
+        for job in jobs:
+            self.assertTrue(job['job'].is_finished)
+            self.assertIn(job['job'].id, job['finished_job_registry'].get_job_ids())
 
     def test_get_unique_connection_configs(self):
         connection_params_1 = {

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -188,6 +188,12 @@ class QueuesTest(TestCase):
         """
         self.assertRaises(ValueError, get_queues, 'default', 'test')
 
+    def test_pass_queue_via_commandline_args(self):
+        """
+        Checks that passing queues via commandline arguments works
+        """
+        self.assertRaises(KeyError, lambda: call_command('rqworker', 'some_queue'))
+
     def test_get_unique_connection_configs(self):
         connection_params_1 = {
             'HOST': 'localhost',

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -192,7 +192,7 @@ class QueuesTest(TestCase):
         """
         Checks that passing queues via commandline arguments works
         """
-        queue_names = ['django_rq_test', 'django_rq_test']
+        queue_names = ['django_rq_test', 'django_rq_test2']
         jobs = []
         for queue_name in queue_names:
             queue = get_queue(queue_name)


### PR DESCRIPTION
This fixes a regression introduced by 2eb4afad which broke passing of queues on Django 1.9 (as reported in #181).