### PR TITLE
Each queue should be able to have its custom_exception or None.

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -77,7 +77,8 @@ class Command(BaseCommand):
                 queues,
                 connection=queues[0].connection,
                 name=options['name'],
-                exception_handlers=get_exception_handlers() or None,
+                exception_handlers=get_exception_handlers(
+                    queues[0].exception_handlers) or None,
                 default_worker_ttl=options['worker_ttl']
             )
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -49,6 +49,7 @@ class DjangoRQ(Queue):
     def __init__(self, *args, **kwargs):
         autocommit = kwargs.pop('autocommit', None)
         self._autocommit = get_commit_mode() if autocommit is None else autocommit
+        self.exception_handlers = kwargs.pop('exception_handlers', None)
 
         super(DjangoRQ, self).__init__(*args, **kwargs)
 
@@ -138,9 +139,13 @@ def get_queue(name='default', default_timeout=None, async=None,
         default_timeout = QUEUES[name].get('DEFAULT_TIMEOUT')
     if queue_class is None:
         queue_class = get_queue_class(QUEUES[name])
+
+    exception_handlers = QUEUES[name].get('EXCEPTION_HANDLERS', None)
+
     return queue_class(name, default_timeout=default_timeout,
                        connection=get_connection(name), async=async,
-                       autocommit=autocommit)
+                       autocommit=autocommit,
+                       exception_handlers=exception_handlers)
 
 
 def get_queue_by_index(index):

--- a/django_rq/test_exception_handler.py
+++ b/django_rq/test_exception_handler.py
@@ -1,0 +1,3 @@
+
+def my_custom_exception():
+    pass

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -99,7 +99,8 @@ RQ_QUEUES = {
         'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 0,
-        'DEFAULT_TIMEOUT': 500
+        'DEFAULT_TIMEOUT': 500,
+        'EXCEPTION_HANDLERS': ['test_exception_handler.my_custom_exception'],
     },
     'test': {
         'HOST': REDIS_HOST,

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -2,17 +2,27 @@ from rq import Worker
 from rq.utils import import_attribute
 
 from .queues import get_queues
-from .settings import EXCEPTION_HANDLERS
 
 
-def get_exception_handlers():
-    """
-    Custom exception handlers could be defined in settings.py:
-    RQ = {
-        'EXCEPTION_HANDLERS': ['path.to.handler'],
+def get_exception_handlers(exception_handlers):
+    """Custom exception handler defined in QUEUE settings:
+    RQ_QUEUES = {
+        'default': {
+            'HOST': 'localhost',
+            'PORT': 6379,
+            'DB': 0,
+            'PASSWORD': '',
+            'DEFAULT_TIMEOUT': 360,
+            'EXCEPTION_HANDLERS': [
+                'test_exception_handler.my_custom_exception'
+            ],
+        }
     }
     """
-    return [import_attribute(path) for path in EXCEPTION_HANDLERS]
+    if exception_handlers:
+        return [import_attribute(exception_handler) for exception_handler in
+                exception_handlers]
+    return None
 
 
 def get_worker(*queue_names):
@@ -20,6 +30,8 @@ def get_worker(*queue_names):
     Returns a RQ worker for all queues or specified ones.
     """
     queues = get_queues(*queue_names)
-    return Worker(queues,
-                  connection=queues[0].connection,
-                  exception_handlers=get_exception_handlers() or None)
+    return Worker(
+        queues,
+        connection=queues[0].connection,
+        exception_handlers=get_exception_handlers(queues[0].exception_handlers)
+    )


### PR DESCRIPTION
Each queue should be able to have its custom_exception or None. 

Make a global custom_exception may lead us to a non desired behavior on other queues. 