### PR TITLE
Remove args in rqworker

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -43,8 +43,6 @@ class Command(BaseCommand):
     python manage.py rqworker high medium low
     """
 
-    args = '<queue queue ...>'
-
     def add_arguments(self, parser):
         parser.add_argument('--worker-class', action='store', dest='worker_class',
                             default='rq.Worker', help='RQ Worker class to use')


### PR DESCRIPTION
With django 1.9.7, the default queue is always selected.

python manage.py rqworker premium
14:42:21 Registering birth of worker rubusidaeus.21159
14:42:21 RQ worker 'rq:worker:rubusidaeus.21159' started, version 0.7.1
14:42:21 Cleaning registries for queue: default
14:42:21
14:42:21 *** Listening on default...
14:42:21 Sent heartbeat to prevent worker timeout. Next one should arrive within 420 seconds.