### PR TITLE
patterns function removed from django

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,9 @@ Installation
 
 .. code-block:: python
 
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^django-rq/', include('django_rq.urls')),
-    )
+    ]
 
 =====
 Usage


### PR DESCRIPTION
deprecated since 1.8, removed in 1.10