### PR TITLE
Fix #231 Improves interface response

### DIFF
--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
@@ -509,11 +508,14 @@ class ViewTest(TestCase):
         )
         self.assertEqual(response.context['jobs'], [job])
 
-    @mock.patch('django_rq.views.get_connection')
-    @mock.patch('django_rq.views.Worker.all')
-    def test_collects_worker_various_connections_get_multiplr_collection(self, worker_all, get_conn):
-        _collect_workers_per_configuration(QUEUES_LIST)
-        self.assertEqual(worker_all.call_count, 10)
+    def test_collects_worker_various_connections_get_multiple_collection(self):
+        queues_list = [
+            {'name': 'default', 'connection_config': settings.RQ_QUEUES['default']},
+            {'name': 'django_rq_test', 'connection_config': settings.RQ_QUEUES['django_rq_test']},
+            {'name': 'django_rq_test2', 'connection_config': settings.RQ_QUEUES['django_rq_test2']},
+        ]
+        collections = _collect_workers_per_configuration(queues_list)
+        self.assertEqual(len(collections), 2)
 
     def test_get_all_workers(self):
         worker1 = get_worker()

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -26,8 +26,7 @@ from django_rq.queues import (
 from django_rq import thread_queue
 from django_rq.settings import QUEUES_LIST
 from django_rq.templatetags.django_rq import to_localtime
-from django_rq.workers import get_worker, collect_workers_per_configuration
-from django_rq.views import _get_all_workers
+from django_rq.workers import get_worker, collect_workers_by_connection, get_all_workers_by_configuration
 
 
 try:
@@ -365,12 +364,12 @@ class WorkersTest(TestCase):
         job.delete()
 
     def test_collects_worker_various_connections_get_multiple_collection(self):
-        queues_list = [
+        queues = [
             {'name': 'default', 'connection_config': settings.RQ_QUEUES['default']},
             {'name': 'django_rq_test', 'connection_config': settings.RQ_QUEUES['django_rq_test']},
             {'name': 'test3', 'connection_config': settings.RQ_QUEUES['test3']},
         ]
-        collections = collect_workers_per_configuration(queues_list)
+        collections = collect_workers_by_connection(queues)
         self.assertEqual(len(collections), 2)
 
 
@@ -521,16 +520,10 @@ class ViewTest(TestCase):
         worker1 = get_worker()
         worker2 = get_worker('test')
         workers_collections = [
-            {
-                'config': {'some_config': 1},
-                'all_workers': [worker1],
-            },
-            {
-                'config': {'some_config': 2},
-                'all_workers': [worker2],
-            }
+            {'config': {'some_config': 1}, 'all_workers': [worker1]},
+            {'config': {'some_config': 2}, 'all_workers': [worker2]},
         ]
-        result = _get_all_workers({'some_config': 1}, workers_collections)
+        result = get_all_workers_by_configuration({'some_config': 1}, workers_collections)
         self.assertEqual(result, [worker1])
 
 

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -14,15 +14,15 @@ from rq.job import Job
 from rq.registry import (DeferredJobRegistry, FinishedJobRegistry,
                          StartedJobRegistry)
 
-from .queues import get_connection, get_queue_by_index
+from .queues import get_connection, get_queue_by_index, filter_connection_params 
 from .settings import QUEUES_LIST
-from .workers import collect_workers_per_configuration
+from .workers import collect_workers_by_connection, get_all_workers_by_configuration
 
 
 @staff_member_required
 def stats(request):
     queues = []
-    workers_collections = collect_workers_per_configuration(QUEUES_LIST)
+    workers_collections = collect_workers_by_connection(QUEUES_LIST)
     for index, config in enumerate(QUEUES_LIST):
 
         queue = get_queue_by_index(index)
@@ -43,7 +43,10 @@ def stats(request):
 
         else:
             connection = get_connection(queue.name)
-            all_workers = _get_all_workers(config['connection_config'], workers_collections)
+            all_workers = get_all_workers_by_configuration(
+                config['connection_config'],
+                workers_collections
+            )
             queue_workers = [worker for worker in all_workers if queue in worker.queues]
             queue_data['workers'] = len(queue_workers)
 
@@ -58,12 +61,6 @@ def stats(request):
 
     context_data = {'queues': queues}
     return render(request, 'django_rq/stats.html', context_data)
-
-
-def _get_all_workers(config, workers_collections):
-    for collection in workers_collections:
-        if config == collection['config']:
-            return collection['all_workers']
 
 
 @staff_member_required

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -16,12 +16,13 @@ from rq.registry import (DeferredJobRegistry, FinishedJobRegistry,
 
 from .queues import get_connection, get_queue_by_index
 from .settings import QUEUES_LIST
+from .workers import collect_workers_per_configuration
 
 
 @staff_member_required
 def stats(request):
     queues = []
-    workers_collections = _collect_workers_per_configuration(QUEUES_LIST)
+    workers_collections = collect_workers_per_configuration(QUEUES_LIST)
     for index, config in enumerate(QUEUES_LIST):
 
         queue = get_queue_by_index(index)
@@ -57,22 +58,6 @@ def stats(request):
 
     context_data = {'queues': queues}
     return render(request, 'django_rq/stats.html', context_data)
-
-
-def _collect_workers_per_configuration(queue_list):
-    """Collects, into a list, dictionaries of connections_config and its
-    workers
-    """
-    workers_collections = []
-    for item in queue_list:
-        if item['connection_config'] not in [c['config'] for c in workers_collections]:
-            connection = get_connection(item['name'])
-            collection = {
-                'config': item['connection_config'],
-                'all_workers': Worker.all(connection=connection)
-            }
-            workers_collections.append(collection)
-    return workers_collections
 
 
 def _get_all_workers(config, workers_collections):

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -1,7 +1,7 @@
 from rq import Worker
 from rq.utils import import_attribute
 
-from .queues import get_queues
+from .queues import get_queues, get_connection, filter_connection_params
 from .settings import EXCEPTION_HANDLERS
 
 
@@ -23,3 +23,20 @@ def get_worker(*queue_names):
     return Worker(queues,
                   connection=queues[0].connection,
                   exception_handlers=get_exception_handlers() or None)
+
+
+def collect_workers_per_configuration(queue_list):
+    """
+    Collects, into a list, dictionaries of connections_config and its workers.
+    """
+    workers_collections = []
+    for item in queue_list:
+        connection_params = filter_connection_params(item['connection_config'])
+        if connection_params not in [c['config'] for c in workers_collections]:
+            connection = get_connection(item['name'])
+            collection = {
+                'config': connection_params,
+                'all_workers': Worker.all(connection=connection)
+            }
+            workers_collections.append(collection)
+    return workers_collections

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -25,12 +25,30 @@ def get_worker(*queue_names):
                   exception_handlers=get_exception_handlers() or None)
 
 
-def collect_workers_per_configuration(queue_list):
+def collect_workers_by_connection(queues):
     """
     Collects, into a list, dictionaries of connections_config and its workers.
+
+    This function makes an association between some configurarion and the
+    workers it uses.
+    What the return may looks like:
+
+        workers_collection = [
+            {
+                'config': {'DB': 0, 'PORT': 6379, 'HOST': 'localhost'},
+                'all_workers': [worker1, worker2],
+            },
+            {
+                'config': {'DB': 1, 'PORT': 6379, 'HOST': 'localhost'},
+                'all_workers': [worker1]
+            }
+        ]
+
+    Use `get_all_workers_by_configuration()` to select a worker group from the
+    collection returned by this function.
     """
     workers_collections = []
-    for item in queue_list:
+    for item in queues:
         connection_params = filter_connection_params(item['connection_config'])
         if connection_params not in [c['config'] for c in workers_collections]:
             connection = get_connection(item['name'])
@@ -40,3 +58,14 @@ def collect_workers_per_configuration(queue_list):
             }
             workers_collections.append(collection)
     return workers_collections
+
+
+def get_all_workers_by_configuration(config, workers_collections):
+    """
+    Gets from a worker_collection the worker group associated to a given
+    configuration
+    """
+    c = filter_connection_params(config)
+    for collection in workers_collections:
+        if c == collection['config']:
+            return collection['all_workers']


### PR DESCRIPTION
In the view `stats`, the query `Worker.all()` is applied to every queue
in the settings, even those which have the same configuration and, thus,
would give the same response.

This commit aims to avoid all unnecessary queries by calling a
preprocessor.