### PR TITLE
Optimise requeue all - resolves #244

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 dist/
 django_rq.egg-info/
 
+# pycharm
+.idea

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -328,20 +328,21 @@ def clear_queue(request, queue_index):
 def requeue_all(request, queue_index):
     queue_index = int(queue_index)
     queue = get_queue_by_index(queue_index)
-    jobs = queue.get_jobs()
 
     if request.method == 'POST':
-        # Confirmation received
-        for job in jobs:
-            requeue_job(job.id, connection=queue.connection)
+        job_ids = queue.get_job_ids()
 
-        messages.info(request, 'You have successfully requeued all %d jobs!' % len(jobs))
+        # Confirmation received
+        for job_id in job_ids:
+            requeue_job(job_id, connection=queue.connection)
+
+        messages.info(request, 'You have successfully requeued all %d jobs!' % len(job_ids))
         return redirect('rq_jobs', queue_index)
 
     context_data = {
         'queue_index': queue_index,
         'queue': queue,
-        'total_jobs':len(jobs),
+        'total_jobs': queue.count,
     }
 
     return render(request, 'django_rq/requeue_all.html', context_data)


### PR DESCRIPTION
Only load job ids when doing requeue all, instead of instantiating job objects, to save resources.

Also added gitignore of pycharm project.