### PR TITLE
Bump test requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 dist/
 django_rq.egg-info/
 
+# pycharm
+.idea

--- a/integration_test/_tests.py
+++ b/integration_test/_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import logging
 import os
@@ -11,10 +11,10 @@ import sys
 import time
 import unittest
 
-from django.conf import settings
 import psycopg2
 import requests
-from six.moves.urllib.parse import urlunsplit
+from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlunsplit
 
 DJANGO_SETTINGS_MODULE = "integration_test.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", DJANGO_SETTINGS_MODULE)

--- a/integration_test/requirements.txt
+++ b/integration_test/requirements.txt
@@ -1,5 +1,5 @@
 -e ..
-Django==1.10.5
-gunicorn==19.6.0
-psycopg2==2.6.2
-requests==2.13.0
+Django==1.11.5
+gunicorn==19.7.1
+psycopg2==2.7.3.1
+requests==2.18.4


### PR DESCRIPTION
Also 

- gitignore pycharm config
- Use Django's six (fixes issue that six was missing from test requirements)
- Pycharm optimise imports on `integration_test/_tests.py`