### PR TITLE
Fix issue displaying deferred queue

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -61,20 +61,24 @@
             </div>
         </div>
 
+        {% if job.created_at %}
         <div class="form-row">
             <div>
                 <label class="required">Created:</label>
                 <div class="data">{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}</div>
             </div>
         </div>
+        {% endif %}
 
+        {% if job.enqueued_at %}
         <div class="form-row">
             <div>
                 <label class="required">Queued:</label>
                 <div class="data">{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}</div>
             </div>
         </div>
-
+        {% endif %}
+        
         {% if job.started_at %}
         <div class="form-row">
             <div>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -84,8 +84,16 @@
                                         {{ job.id }}
                                     </a>
                                 </th>
-                                <td>{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}</td>
-                                <td>{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}</td>
+                                <td>
+                                    {% if job.created_at %}
+                                        {{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if job.enqueued_at %}
+                                        {{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                    {% endif %}
+                                </td>
                                 <td>{{ job.get_status }}</td>
                                 <td>{{ job.func_name }}</td>
                             </tr>

--- a/django_rq/templatetags/django_rq.py
+++ b/django_rq/templatetags/django_rq.py
@@ -12,9 +12,6 @@ def to_localtime(time):
         localtime base on settings
     '''
 
-    if not time:
-        return None
-    
     utc_time = time.replace(tzinfo=timezone.utc)
     to_zone = timezone.get_default_timezone()
     return utc_time.astimezone(to_zone)

--- a/django_rq/templatetags/django_rq.py
+++ b/django_rq/templatetags/django_rq.py
@@ -11,6 +11,10 @@ def to_localtime(time):
         A function to convert naive datetime to
         localtime base on settings
     '''
+
+    if not time:
+        return None
+    
     utc_time = time.replace(tzinfo=timezone.utc)
     to_zone = timezone.get_default_timezone()
     return utc_time.astimezone(to_zone)


### PR DESCRIPTION
A simple fix to allow object passed into to_localtime to be None and not cause an exception to be thrown. Specifically fixes an issue that I was seeing when viewing the deferred queue.

Closes #250 