### PR TITLE
Add support for sentry parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ modifies the default admin template.
 
 Configuring Sentry
 -------------------
-Use ``sentry-dsn`` parameter when running rqworker. ``./manage.py rqworker sentry-dsn=https://*****@sentry.io/222222`` 
+Use ``sentry-dsn`` parameter when running rqworker. ``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222`` 
 
 Configuring Logging
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,9 @@ You can also add a link to this dashboard link in ``/admin`` by adding
 override the default admin template so it may interfere with other apps that
 modifies the default admin template.
 
+Configuring Sentry
+-------------------
+Use ``sentry-dsn`` parameter when running rqworker. ``./manage.py rqworker sentry-dsn=https://*****@sentry.io/222222`` 
 
 Configuring Logging
 -------------------

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -96,11 +96,15 @@ class Command(BaseCommand):
             reset_db_connections()
 
             if sentry_dsn:
-                from raven import Client
-                from raven.transport.http import HTTPTransport
-                from rq.contrib.sentry import register_sentry
-                client = Client(sentry_dsn, transport=HTTPTransport)
-                register_sentry(client, w)
+                try:
+                    from raven import Client
+                    from raven.transport.http import HTTPTransport
+                    from rq.contrib.sentry import register_sentry
+                    client = Client(sentry_dsn, transport=HTTPTransport)
+                    register_sentry(client, w)
+                except ImportError:
+                    self.stdout.write(self.style.ERROR("Please install sentry. For example `pip install raven`"))
+                    sys.exit(1)
 
             w.work(burst=options.get('burst', False))
         except ConnectionError as e:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-rq',
-    version='0.9.6',
+    version='0.9.7',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['django_rq'],
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.8.0', 'rq>=0.5.5'],
+    install_requires=['django>=1.8.0', 'rq>=0.5.5','raven>=6.1.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.8.0', 'rq>=0.5.5','raven>=6.1.0'],
+    install_requires=['django>=1.8.0', 'rq>=0.5.5'],
+    extras_require = {
+        'Sentry':  ['raven>=6.1.0']
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Hello,

Added same support rqworker original command has for sentry.
Use ``sentry-dsn`` parameter when running rqworker. ``./manage.py rqworker sentry-dsn=https://*****@sentry.io/222222``