### PR TITLE
Show New statistics from rq 0.9.x on worker details page

### DIFF
--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -24,7 +24,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Queued Jobs</th>
-                    <th>Oldests Queued Timestamp</th>
+                    <th>Oldest Queued Job</th>
                     <th>Active Jobs</th>
                     <th>Deferred Jobs</th>
                     <th>Finished Jobs</th>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -24,6 +24,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Queued Jobs</th>
+                    <th>Oldests Queued Timestamp</th>
                     <th>Active Jobs</th>
                     <th>Deferred Jobs</th>
                     <th>Finished Jobs</th>
@@ -42,6 +43,7 @@
                             </a>
                         </th>
                         <td>{{ queue.jobs }}</td>
+                        <td>{{ queue.oldest_job_timestamp }}</td>
                         <th>
                             {% if queue.name != 'failed' %}
                                 <a href = "{% url 'rq_started_jobs' queue.index %}">

--- a/django_rq/templates/django_rq/worker_details.html
+++ b/django_rq/templates/django_rq/worker_details.html
@@ -88,7 +88,34 @@
                 </div>
             </div>
         </div>
-        
+
+        {% endif %}
+
+        {% if worker.successful_job_count %}
+            <div class="form-row">
+                <div>
+                    <label class="required">Successful job count:</label>
+                    <div class="data">{{ worker.successful_job_count }}</div>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if worker.failed_job_count %}
+            <div class="form-row">
+                <div>
+                    <label class="required">Failed job count:</label>
+                    <div class="data">{{ worker.failed_job_count }}</div>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if worker.total_working_time %}
+            <div class="form-row">
+                <div>
+                    <label class="required">Total working time:</label>
+                    <div class="data">{{ worker.total_working_time }}</div>
+                </div>
+            </div>
         {% endif %}
 
     </fieldset>

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -20,10 +20,10 @@ def get_statistics():
         last_job_id = connection.lindex(queue.key, -1)
         last_job = queue.fetch_job(last_job_id.decode('utf-8')) if last_job_id else None
         if last_job:
-            queue.oldest_job_timestamp = to_localtime(last_job.enqueued_at)\
+            oldest_job_timestamp = to_localtime(last_job.enqueued_at)\
                 .strftime('%Y-%m-%d, %H:%M:%S')
         else:
-            queue.oldest_job_timestamp = "-"
+            oldest_job_timestamp = "-"
 
         # parse_class is not needed and not JSON serializable
         try:
@@ -34,7 +34,7 @@ def get_statistics():
         queue_data = {
             'name': queue.name,
             'jobs': queue.count,
-            'oldest_job_timestamp': queue.oldest_job_timestamp,
+            'oldest_job_timestamp': oldest_job_timestamp,
             'index': index,
             'connection_kwargs': connection_kwargs
         }


### PR DESCRIPTION
rq 0.9.x introduce some new worker statistics. This PR shows that in the django admin worker details page.

Also, added `oldest_queued_timestamp` to queue statistics

